### PR TITLE
Gen parsing

### DIFF
--- a/GeneratorInterface/LHEInterface/BuildFile.xml
+++ b/GeneratorInterface/LHEInterface/BuildFile.xml
@@ -13,6 +13,7 @@
 <use name="libhepml"/>
 <use name="fastjet"/>
 <use name="xz"/>
+<use name="tinyxml2"/>
 <export>
 	<use name="FWCore/ParameterSet"/>
 	<use name="FWCore/PluginManager"/>

--- a/GeneratorInterface/LHEInterface/interface/LHEWeightGroupReaderHelper.h
+++ b/GeneratorInterface/LHEInterface/interface/LHEWeightGroupReaderHelper.h
@@ -12,328 +12,284 @@
 #include "SimDataFormats/GeneratorProducts/interface/ScaleWeightGroupInfo.h"
 #include "SimDataFormats/GeneratorProducts/interface/LHERunInfoProduct.h"
 
+#include <tinyxml2.h>
+using namespace tinyxml2;
 
-namespace dylanTest {
-    class RegexCreater
-    {
-    public:
-	void addValue(std::string baseName, std::vector<std::string> altNames={}, bool isInContent=false );
-	bool processString(std::string);
-	std::map<std::string, std::string> getTagMap() {return valueMap;}
 
+class LHEWeightGroupReaderHelper {
+public:
+    LHEWeightGroupReaderHelper();
+
+    //// possibly add more versions of this functions for different inputs
+    void parseLHEFile(std::string filename);
+    void parseWeightGroupsFromHeader(std::vector<std::string> lheHeader);
+
+
+    edm::OwnVector<gen::WeightGroupInfo> getWeightGroups() {return weightGroups_;}
+private:
+    void loadAttributeNames(std::string baseName, std::vector<std::string> altNames ={});
+    std::string toLowerCase(const char*);
+    std::string toLowerCase(const std::string);
+    std::map<std::string, std::string> getAttributeMap(std::string);
+    std::string sanitizeText(std::string);
+    bool isAWeight(std::string);
     
-    private:
-	std::string tagRegString = "(?:)";
-	std::string contentRegString = "(?:)";
-
-	std::vector<std::string> tagNames;
-	std::vector<std::string> contentNames;
-     
-	std::regex tagRegex;
-	std::regex contentRegex;
-
-	std::map<std::string, std::string> valueMap;
+    // Variables
+    edm::OwnVector<gen::WeightGroupInfo> weightGroups_;
+    std::regex weightGroupStart_;
+    std::regex weightGroupEnd_;
+    std::regex weightContent_;
     
-	std::string orStrings(std::string baseName, std::vector<std::string> altNames);
-	void updateRegexSearchTag(std::string matchName);
-	void updateRegexSearchContent(std::string matchName);
-    
-    };
+    std::map<std::string, std::string> nameConvMap;
+};
 
 
-    
-
-    class LHEWeightGroupReaderHelper {
-    public:
-	LHEWeightGroupReaderHelper();
-
-	//// possibly add more versions of this functions for different inputs
-	void parseLHEFile(std::string filename);
-	void parseWeightGroupsFromHeader(std::vector<std::string> lheHeader);
-
-
-	edm::OwnVector<gen::WeightGroupInfo> getWeightGroups() {return weightGroups_;}
-    
-    private:
-	// functions
-	std::map<std::string, std::string> getMap_testAll(std::string, std::vector<RegexCreater>);
-	
-	// Variables
-	edm::OwnVector<gen::WeightGroupInfo> weightGroups_;
-	std::regex weightGroupStart_;
-	std::regex weightGroupEnd_;
-	std::regex weightContent_;
-	std::regex scaleWeightMatch_;
-
-	std::vector<RegexCreater> regexOptions;
-	RegexCreater weightGroupInfo;
-    };
-}
-
-
-
-void
-dylanTest::RegexCreater::addValue(std::string baseName, std::vector<std::string> altNames, bool isInContent) {
-    std::string nameListString = orStrings(baseName, altNames);
-
-    if (isInContent) {
-	contentNames.push_back(baseName);
-	updateRegexSearchContent(nameListString);
-    }
-    else {
-	tagNames.push_back(baseName);
-	updateRegexSearchTag(nameListString);
-    }
+std::string
+LHEWeightGroupReaderHelper::toLowerCase(const char* name) {
+    std::string returnStr;
+    for (size_t i = 0; i < strlen(name); ++i)
+        returnStr.push_back(tolower(name[i]));
+    return returnStr;
 }
 
 std::string
-dylanTest::RegexCreater::orStrings(std::string baseName, std::vector<std::string> altNames) {
-    for(auto name: altNames) {
-	baseName += "|" + name;
-    }
-    return baseName;
-}
+LHEWeightGroupReaderHelper::toLowerCase(const std::string name) {
+    std::string returnStr = name;
+    transform(name.begin(), name.end(), returnStr.begin(), ::tolower);    
+    return returnStr;
 
-void
-dylanTest::RegexCreater::updateRegexSearchTag(std::string matchName) {
-    tagRegString.pop_back(); 	// remove last )
-    if(tagRegString.size() > 5) tagRegString += "|";//for fence post issue
-	
-    tagRegString += "\\s*(" + matchName + ")=\"([^\"]+)\")";
-    // Last bit is to ignore case
-    tagRegex = std::regex(tagRegString, std::regex_constants::ECMAScript | std::regex_constants::icase );
-}
-
-void
-dylanTest::RegexCreater::updateRegexSearchContent(std::string matchName) {
-    contentRegString.pop_back();    // remove last )
-    if(contentRegString.size() > 5) contentRegString += "|";  //for fence post issue
-    contentRegString += "(" + matchName + ")\\s*=\\s*(\\S+))";
-    // Last bit is to ignore case
-    contentRegex = std::regex(contentRegString, std::regex_constants::ECMAScript | std::regex_constants::icase );
-}
     
-bool
-dylanTest::RegexCreater::processString(std::string fullString) {
-    valueMap.clear();
-    std::smatch m;
+}
 
-    std::string processStr = fullString;
-    while(std::regex_search(processStr, m, tagRegex)) {
-	for(int i = 1; i < m.length() - 1; i += 2) {
-	    if(m[i] != "") {
-		valueMap[tagNames.at(i/2)] = m[i + 1];
-	    }
-
-	}
-	processStr = m.suffix().str();
+void LHEWeightGroupReaderHelper::loadAttributeNames(std::string baseName, std::vector<std::string> altNames) {
+    for(auto altname : altNames) {
+        nameConvMap[altname] = baseName;
     }
+    nameConvMap[baseName] = baseName;
+}
 
-    std::regex weightContent_ = std::regex("<weight.*>\\s*(.+)\\s*</weight>");
-    std::regex_search(fullString, m, weightContent_);
-    processStr = m[1];
-    while(std::regex_search(processStr, m, contentRegex)) {
-	for(int i = 1; i < m.length() - 1; i += 2) {
-	    if(m[i] != "") {
-		valueMap[contentNames.at(i/2)] = m[i + 1];
-	    }
+std::string
+LHEWeightGroupReaderHelper::sanitizeText(std::string line) {
+    std::map<std::string, std::string > replaceMap = {{"&lt;", "<"}, {"&gt;", ">"}};
+
+    for(auto pair: replaceMap) {
+	std::string badText = pair.first;
+	std::string goodText = pair.second;
+	while(line.find(badText) != std::string::npos) {
+	    size_t spot = line.find(badText);
+	    line.replace(spot, badText.size(), goodText);
 	}
-	processStr = m.suffix().str();
     }
-
-    return valueMap.size() == (contentNames.size() + tagNames.size());
+    return line;
 }
 
 
-
-
-
-
-
-
-dylanTest::LHEWeightGroupReaderHelper::LHEWeightGroupReaderHelper() {
+LHEWeightGroupReaderHelper::LHEWeightGroupReaderHelper() {
     weightGroupStart_ = std::regex(".*<weightgroup.+>.*\n*");
     weightGroupEnd_ = std::regex(".*</weightgroup>.*\n*");
-    weightContent_ = std::regex("<weight.*>\\s*(.+)\\s*</weight>\n*");
-    scaleWeightMatch_ = std::regex(".*(Central scale variation|scale_variation).*\n?");
-
+    
     std::cout << "Init" << "\n";
     
     /// Might change later, order matters and code doesn't pick choices
 
-    // WZVBS_2017_weightInfo.txt : scale-sometimes
-    // WZVBS_private_weightInfo.txt : scale-sometimes
-    RegexCreater rc_scale_dyn_pdf;
-    rc_scale_dyn_pdf.addValue("muf");
-    rc_scale_dyn_pdf.addValue("mur");
-    rc_scale_dyn_pdf.addValue("id");
-    rc_scale_dyn_pdf.addValue("dyn_scale");
-    rc_scale_dyn_pdf.addValue("pdf");
-    regexOptions.push_back(rc_scale_dyn_pdf);
+    // Used for translating different naming convention to a common one
+    loadAttributeNames("muf", {"facscfact"});
+    loadAttributeNames("mur", {"renscfact"});
+    loadAttributeNames("id");
+    loadAttributeNames("pdf", {"pdf set", "lhapdf", "pdfset"});
+    loadAttributeNames("dyn_scale");
 
-    // WZVBS_private_weightInfo.txt : scale-sometimes / other
-    // WZVBS_2017_weightInfo.txt : scale-sometimes / other
-    // DrellYan_LO_MGMLMv242_2017_weightInfo.txt : all
-    RegexCreater rc_scale_pdf;
-    rc_scale_pdf.addValue("muf");
-    rc_scale_pdf.addValue("mur");
-    rc_scale_pdf.addValue("id");
-    rc_scale_pdf.addValue("pdf");
-    regexOptions.push_back(rc_scale_pdf);
-
-	
-    RegexCreater rc_scale;
-    rc_scale.addValue("muf");
-    rc_scale.addValue("mur");
-    rc_scale.addValue("id");
-    regexOptions.push_back(rc_scale);
-
-
-    // ZZTo4L_powheg_2016_weightInfo.txt : scale / missing pdf option though...
-    // DrellYan_NLO_MGFXFXv233_2016_weightInfo.txt : scale
-    // DrellYan_LO_MGMLMv233_2016_weightInfo.txt : scale
-    RegexCreater rc_scaleAlt;
-    rc_scaleAlt.addValue("muf", {"facscfact"}, true);
-    rc_scaleAlt.addValue("mur", {"renscfact"}, true);
-    rc_scaleAlt.addValue("id");
-    regexOptions.push_back(rc_scaleAlt);
-
-
-    // ZZTo4L_powheg_2016_weightInfo.txt : other
-    // ZZTo4L_powheg_2017_weightInfo.txt : other
-    // DrellYan_NLO_MGFXFXv242_2017_weightInfo.txt : other
-    // DrellYan_NLO_MGFXFXv233_2016_weightInfo.txt : other
-    RegexCreater rc_pdfAlt;
-    rc_pdfAlt.addValue("pdf", {"pdf set", "lhapdf", "pdfset"}, true);
-    rc_pdfAlt.addValue("id");
-    regexOptions.push_back(rc_pdfAlt);
-    
-    // DrellYan_LO_MGMLMv233_2016_weightInfo.txt : other
-    RegexCreater rc_idOnly;
-    rc_idOnly.addValue("id");
-    regexOptions.push_back(rc_idOnly);
-    
-    weightGroupInfo.addValue("name", {"type"});
-    weightGroupInfo.addValue("combine");
-
+    loadAttributeNames("combine");
+    loadAttributeNames("name", {"type"});
 
 }
 
-std::map<std::string , std::string>
-dylanTest::LHEWeightGroupReaderHelper::getMap_testAll(std::string line, std::vector<RegexCreater> options) {
-    for (size_t i = 0; i < options.size(); ++i) {
-	if(options[i].processString(line)) {
-	    return options[i].getTagMap();
-	}
+std::map<std::string, std::string>
+LHEWeightGroupReaderHelper::getAttributeMap(std::string line) {
+    XMLDocument xmlParser;
+    int error = xmlParser.Parse(line.c_str());
+    if (error) {
+        std::cout << "we have a problem!" << "\n";
+	return std::map<std::string , std::string >();
+	//do something....
     }
-    ////// problem!!!!
-    std::cout << "problem!!" << "\n";
-    return std::map<std::string , std::string >();
-}
 
-
-void
-dylanTest::LHEWeightGroupReaderHelper::parseLHEFile(std::string filename) {
-    std::ifstream file;
-    file.open(filename);
-
-    std::string line;
-    std::smatch matches;
-    // TODO: Not sure the weight indexing is right here, this seems to more or less
-    // count the lines which isn't quite the goal. TOCHECK!
-    int index = 0;
-    while(getline(file, line)) {
-	if(std::regex_match(line, weightGroupStart_)) {
-	    std::string name = getMap_testAll(line, {weightGroupInfo})["name"];
-                
-	    //TODO: Fine for now, but in general there should also be a check on the PDF weights,
-	    // e.g., it could be an unknown weight
-	    
-	    if(std::regex_match(name, scaleWeightMatch_)) {
-		weightGroups_.push_back(new gen::ScaleWeightGroupInfo(line));
-		std::cout << "scale weight" << "\n";
-	    }
-
-
-	    else
-		weightGroups_.push_back(new gen::PdfWeightGroupInfo(line));
-
-	    /// file weights
-	    while(getline(file, line) && !std::regex_match(line, weightGroupEnd_)) {
-		auto tagsMap = getMap_testAll(line, regexOptions);
-                
-		std::regex_search(line, matches, weightContent_);
-		// TODO: Add proper check that it worked
-		std::string content = matches[1].str();
-
-		auto& group = weightGroups_.back();
-		if (group.weightType() == gen::kScaleWeights) {
-		    float muR = std::stof(tagsMap["mur"]);
-		    float muF = std::stof(tagsMap["muf"]);
-		    auto& scaleGroup = static_cast<gen::ScaleWeightGroupInfo&>(group);
-		    scaleGroup.addContainedId(index, tagsMap["id"], line, muR, muF);
-		}
-		else
-		    group.addContainedId(index, tagsMap["id"], line);
-
-		index++;                        
+    std::map<std::string, std::string> attMap;
+    XMLElement* element = xmlParser.FirstChildElement();
+    
+    for( const XMLAttribute* a = element->FirstAttribute(); a; a=a->Next()) {
+        attMap[nameConvMap[toLowerCase(a->Name())]] = a->Value();
+    }
+    // get stuff from content of tag if it has anything.
+    // always assume format is AAAAA=(  )BBBB    (  ) => optional space
+    if (element->GetText() == nullptr) {
+        return attMap;
+    }
+    // This adds "content: " to the beginning of the content. not sure if its a big deal or?
+    std::string content = element->GetText();
+    attMap["content"] = content;
+    
+    std::regex reg("(?:(\\S+)=\\s*(\\S+))");
+    std::smatch m;
+    while(std::regex_search(content, m, reg)) {
+	std::string key = nameConvMap[toLowerCase(m.str(1))];
+	if (attMap[key] != std::string()) {
+	    if (m[2] != attMap[key]) {
+		std::cout << m.str(2) << " vs " << attMap[key];
+		// might do something if content and attribute don't match?
+		// but need to be careful since some are purposefully different
+		// eg dyn_scale is described in content but just given a number
 	    }
 	}
+	else {
+	    attMap[key] = m.str(2);
+	}
+	content = m.suffix().str();
     }
+    return attMap;
+    
 }
 
+bool
+LHEWeightGroupReaderHelper::isAWeight(std::string line) {
+    XMLDocument xmlParser;
+    int error = xmlParser.Parse(line.c_str());
+    if (error) {
+	return false;
+	//do something....
+    }
+    XMLElement* element = xmlParser.FirstChildElement();
+    return element;
+}
+
+// void
+// LHEWeightGroupReaderHelper::parseLHEFile(std::string filename) {
+//     std::ifstream file;
+//     file.open(filename);
+
+//     std::string line;
+//     std::smatch matches;
+//     // TODO: Not sure the weight indexing is right here, this seems to more or less
+//     // count the lines which isn't quite the goal. TOCHECK!
+//     int index = 0;
+//     while(getline(file, line)) {
+//      if(std::regex_match(line, weightGroupStart_)) {
+//          std::string name = getMap_testAll(line, {weightGroupInfo})["name"];
+                
+//          //TODO: Fine for now, but in general there should also be a check on the PDF weights,
+//          // e.g., it could be an unknown weight
+            
+//          if(std::regex_match(name, scaleWeightMatch_)) {
+//              weightGroups_.push_back(new gen::ScaleWeightGroupInfo(line));
+//              std::cout << "scale weight" << "\n";
+//          }
+
+
+//          else
+//              weightGroups_.push_back(new gen::PdfWeightGroupInfo(line));
+
+//          /// file weights
+//          while(getline(file, line) && !std::regex_match(line, weightGroupEnd_)) {
+//              auto tagsMap = getMap_testAll(line, regexOptions);
+                
+//              std::regex_search(line, matches, weightContent_);
+//              // TODO: Add proper check that it worked
+//              std::string content = matches[1].str();
+
+//              auto& group = weightGroups_.back();
+//              if (group.weightType() == gen::kScaleWeights) {
+//                  float muR = std::stof(tagsMap["mur"]);
+//                  float muF = std::stof(tagsMap["muf"]);
+//                  auto& scaleGroup = static_cast<gen::ScaleWeightGroupInfo&>(group);
+//                  scaleGroup.addContainedId(index, tagsMap["id"], line, muR, muF);
+//              }
+//              else
+//                  group.addContainedId(index, tagsMap["id"], line);
+
+//              index++;                        
+//          }
+//      }
+//     }
+// }
+
 void
-dylanTest::LHEWeightGroupReaderHelper::parseWeightGroupsFromHeader(std::vector<std::string> lheHeader) {
-    std::smatch matches;
+LHEWeightGroupReaderHelper::parseWeightGroupsFromHeader(std::vector<std::string> lheHeader) {
     // TODO: Not sure the weight indexing is right here, this seems to more or less
     // count the lines which isn't quite the goal. TOCHECK!
     int index = 0;
     bool foundGroup = false;
+    
     for (std::string headerLine : lheHeader) {
 	std::cout << "Header line is:" << headerLine;
+	headerLine = sanitizeText(headerLine);
+        std::cout << "Header line is:" << weightGroups_.size() << " "<< headerLine;
 	//TODO: Fine for now, but in general there should also be a check on the PDF weights,
-	// e.g., it could be an unknown weight
-	//std::cout << "weightGroupStart_ .*<weightgroup.+>.* ... match? " << static_cast<int>(std::regex_match(headerLine, weightGroupStart_)) << std::endl;
-	if (std::regex_match(headerLine, weightGroupStart_)) {
-	    //std::cout << "Adding new group for headerLine" << std::endl;
-	    foundGroup = true;
-	    std::string name = getMap_testAll(headerLine, {weightGroupInfo})["name"];
+        // e.g., it could be an unknown weight
+        
+        if (std::regex_match(headerLine, weightGroupStart_)) {
+            //std::cout << "Adding new group for headerLine" << std::endl;
+            foundGroup = true;
+            std::string fullTag = headerLine + "</weightgroup>";
+            auto groupMap = getAttributeMap(fullTag);
+            std::string name = groupMap["name"];
                 
-	    if(std::regex_match(name, scaleWeightMatch_)) {
-		weightGroups_.push_back(new gen::ScaleWeightGroupInfo(headerLine));
-		std::cout << "scale weight" << "\n";
-	    }
-            
+            if(name.find("Central scale variation") != std::string::npos ||
+               name.find("scale_variation") != std::string::npos) {
+                weightGroups_.push_back(new gen::ScaleWeightGroupInfo(headerLine));
+                std::cout << "scale weight" << "\n";
+            }
 	    else
 		weightGroups_.push_back(new gen::PdfWeightGroupInfo(headerLine));
-	}
-	/// file weights
-	else if (foundGroup && !std::regex_match(headerLine, weightGroupEnd_)) {
-	    //std::cout << "Adding new weight for headerLine" << std::endl;
-	    auto tagsMap = getMap_testAll(headerLine, regexOptions);
+        }
+        /// file weights
+        else if (foundGroup && isAWeight(headerLine)) {
+            //std::cout << "Adding new weight for headerLine" << std::endl;
+            auto tagsMap = getAttributeMap(headerLine);
 	    for(auto pair: tagsMap) {
 		std::cout << pair.first << ": " << pair.second << " | ";
 	    }
-	    std::cout << "\n";
-	    std::regex_search(headerLine, matches, weightContent_);
-	    // TODO: Add proper check that it worked
-	    std::string content = matches[1].str();
-	    // std::cout << content << "\n";
-	    
-	    auto& group = weightGroups_.back();
-	    if (group.weightType() == gen::kScaleWeights) {
-		float muR = std::stof(tagsMap["mur"]);
-		float muF = std::stof(tagsMap["muf"]);
-		std::cout << tagsMap["id"] << " " << muR << " " << muF << " " << content << "\n";
-		auto& scaleGroup = static_cast<gen::ScaleWeightGroupInfo&>(group);
+            std::cout << "\n";
+            
+            std::string content = tagsMap["content"];
+            if (tagsMap["id"] == std::string()) {
+                std::cout << "error" << "\n";
+                // should do something
+            }
+            
+            auto& group = weightGroups_.back();
+            if (group.weightType() == gen::kScaleWeights) {
+                if (tagsMap["mur"] == std::string() || tagsMap["muf"] == std::string()) {
+                    std::cout << "error" << "\n";
+                    // something should happen here
+		    continue;
+                }
+                float muR = std::stof(tagsMap["mur"]);
+                float muF = std::stof(tagsMap["muf"]);
+                std::cout << tagsMap["id"] << " " << muR << " " << muF << " " << content << "\n";
+                auto& scaleGroup = static_cast<gen::ScaleWeightGroupInfo&>(group);
 		scaleGroup.addContainedId(index, tagsMap["id"], headerLine, muR, muF);
-	    }
-	    else
-		group.addContainedId(index, tagsMap["id"], headerLine);
-	    index++;
+            }
+            else
+                group.addContainedId(index, tagsMap["id"], headerLine);
+            index++;
 	}
-	else {
+	// commented out since code doesn't work with this in....
+	// else if(isAWeight(headerLine)) {
+	//     // found header. Don't know what to do with it so just shove it into a new weightgroup for now
+	//     // do minimum work for it
+	//     weightGroups_.push_back(new gen::PdfWeightGroupInfo(headerLine));
+	//     auto& group = weightGroups_.back();
+	//     auto tagsMap = getAttributeMap(headerLine);
+	//     group.addContainedId(index, tagsMap["id"], headerLine);
+	//     foundGroup = true;
+	//     index++;
+	// }
+	
+	else if(std::regex_match(headerLine, weightGroupEnd_)) {
 	    foundGroup = false;
+	} 
+	else {
+            std::cout << "problem!!!" << "\n";
 	}
     }
 }

--- a/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
+++ b/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
@@ -372,22 +372,8 @@ ExternalLHEProducer::beginRunProduce(edm::Run& run, edm::EventSetup const& es)
 	run.put(std::move(product));
   
 	std::unique_ptr<LHEWeightInfoProduct> weightInfoProduct(new LHEWeightInfoProduct);
-	//gen::WeightGroupInfo scaleInfo;// = getExampleScaleWeights();
-	//edm::OwnVector<gen::WeightGroupInfo> pdfSets;// = getExamplePdfWeights();
-	//gen::WeightGroupInfo scaleInfo = getExampleScaleWeightsOutOfOrder();
 
-	// setup file reader
-	//std::string LHEfilename ="cmsgrid_final.lhe";
-	//	std::string LHEfilename = "DrellYan_LO_MGMLMv233_2016_weightInfo.txt";
-	//std::string LHEfilename = "DrellYan_LO_MGMLMv242_2017_weightInfo.txt";
-	// std::string LHEfilename = "DrellYan_NLO_MGFXFXv233_2016_weightInfo.txt";
-	// std::string LHEfilename = "DrellYan_NLO_MGFXFXv242_2017_weightInfo.txt";
-	// std::string LHEfilename = "WZVBS_2017_weightInfo.txt"; // ****
-	std::string LHEfilename = "WZVBS_private_weightInfo.txt";
-	// std::string LHEfilename = "ZZTo4L_powheg_2016_weightInfo.txt";
-	// std::string LHEfilename = "ZZTo4L_powheg_2017_weightInfo.txt";
-
-	dylanTest::LHEWeightGroupReaderHelper reader;
+	LHEWeightGroupReaderHelper reader;
 	//reader.parseLHEFile(LHEfilename);
 	std::cout << "Trying to find header initrwgt. Size is ";
 	std::cout << runInfo->findHeader("initrwgt").size() << std::endl;

--- a/GeneratorInterface/LHEInterface/test/test_Weights_cfg.py
+++ b/GeneratorInterface/LHEInterface/test/test_Weights_cfg.py
@@ -59,12 +59,18 @@ from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, '102X_upgrade2018_realistic_v11', '')
 
 process.externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
-    args = cms.vstring('/afs/hep.wisc.edu/home/kdlong/public/DarkMatter_MonoZPrime_V_Mx50_Mv500_gDMgQ1_LO_slc6_amd64_gcc481_CMSSW_7_1_30_tarball_Dummy.tgz'),
-    nEvents = cms.untracked.uint32(10),
+                                             args = cms.vstring('/afs/cern.ch/user/k/kelong/work/public/DummyGridpacks/WLLJJ_WToLNu_EWK_4F_MLL-60_slc6_amd64_gcc481_CMSSW_7_1_30_tarball_Dummy.tgz'),
+                                             nEvents = cms.untracked.uint32(10),
     numberOfParameters = cms.uint32(1),
     outputFile = cms.string('cmsgrid_final.lhe'),
     scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
 )
+
+# args = cms.vstring('/afs/cern.ch/user/k/kelong/work/public/DummyGridpacks/DarkMatter_MonoZPrime_V_Mx50_Mv500_gDMgQ1_LO_slc6_amd64_gcc481_CMSSW_7_1_30_tarball_Dummy.tgz'),
+# args = cms.vstring('/afs/cern.ch/user/k/kelong/work/public/DummyGridpacks/WLLJJ_WToLNu_EWK_4F_MLL-60_slc6_amd64_gcc481_CMSSW_7_1_30_tarball_Dummy.tgz'),
+# args = cms.vstring('/afs/cern.ch/user/k/kelong/work/public/DummyGridpacks/ZZ_4L_NNPDF30_13TeV_tarballDummy.tar.gz'),
+# args = cms.vstring('/afs/cern.ch/user/k/kelong/work/public/DummyGridpacks/ZZ_slc6_amd64_gcc630_CMSSW_9_3_0_ZZTo4L2017_pdf306000Dummy.tgz'),
+
 
 
 # Path and EndPath definitions
@@ -78,6 +84,8 @@ from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
 associatePatAlgosToolsTask(process)
 
 
+
+ 
 # Customisation from command line
 
 # Add early deletion of temporary data products to reduce peak memory need


### PR DESCRIPTION
Did an overhaul of the code base to use the tinyxml reader instead of regexs

## notes
- I removed the namespace and RegexCreater class because they shouldn't be necessary anymore
- I put in a few comments for places to put error checks in. Still tbd what we want to do with them
- I specifically tried to remove most of the regex. There is still some left for convenience and we might actually want to put some back since I did some things to make the code work with the xml reader, eg

https://github.com/dteague/cmssw/blob/b4b08c9a6bd41511ddd4a1b8f89a99e3d0f15b21/GeneratorInterface/LHEInterface/interface/LHEWeightGroupReaderHelper.h#L232-L233

- There is a big problem with the group assigning. In the file `WLLJJ_WToLNu_EWK_4F_MLL-60_slc6_amd64_gcc481_CMSSW_7_1_30_tarball_Dummy.tgz`, the file has some weights outside of the weightgroup. I put in some code to handle this, ie 

https://github.com/dteague/cmssw/blob/b4b08c9a6bd41511ddd4a1b8f89a99e3d0f15b21/GeneratorInterface/LHEInterface/interface/LHEWeightGroupReaderHelper.h#L276-L286

Basically it creates a new weight group and puts the unclaimed weights into it. It doesn't play well with the weightgroupinfo class though... it throws a vector error that I'm guessing has something to do with the id? idk, so i commented it out for now and code sort of works... It breaks in the cleanup at the end, so that's probably something wrong with the weight reader, or? Needs to be investigated.