### PR TITLE
WIP: Improved parsing... more improved!

### DIFF
--- a/GeneratorInterface/Core/interface/WeightHelper.h
+++ b/GeneratorInterface/Core/interface/WeightHelper.h
@@ -46,11 +46,10 @@ namespace gen {
     bool isMEParamWeightGroup(const ParsedWeight& weight);
     bool isPdfWeightGroup(const ParsedWeight& weight);
     bool isOrphanPdfWeightGroup(ParsedWeight& weight);
-    bool isMultiSetPdfGroup(WeightGroupInfo& group);
     void updateScaleInfo(const ParsedWeight& weight);
     void updatePdfInfo(const ParsedWeight& weight);
-    void updatePdfInfo(int lhaid, int index);
     void splitPdfGroups();
+    int getLhapdfId(const ParsedWeight& weight);
     std::string searchAttributes(const std::string& label, const ParsedWeight& weight) const;
     std::string searchAttributesByTag(const std::string& label, const ParsedWeight& weight) const;
     std::string searchAttributesByRegex(const std::string& label, const ParsedWeight& weight) const;

--- a/GeneratorInterface/Core/interface/WeightHelper.h
+++ b/GeneratorInterface/Core/interface/WeightHelper.h
@@ -59,8 +59,8 @@ namespace gen {
         {"muf", {"muF", "MUF", "muf", "facscfact"}},
         {"mur", {"muR", "MUR", "mur", "renscfact"}},
         {"pdf", {"PDF", "PDF set", "lhapdf", "pdf", "pdf set", "pdfset"}},
-        //{"dyn", {"DYN_SCALE", "dyn_scale_choice"}},
-    };
+        {"dyn", {"DYN_SCALE"}},
+        {"dyn_name", {"dyn_scale_choice"}}};
   };
 }  // namespace gen
 

--- a/GeneratorInterface/Core/interface/WeightHelper.h
+++ b/GeneratorInterface/Core/interface/WeightHelper.h
@@ -16,12 +16,6 @@
 #include <fstream>
 
 namespace gen {
-  struct PdfSetInfo {
-    std::string name;
-    int lhapdfId;
-    PdfUncertaintyType uncertaintyType;
-  };
-
   struct ParsedWeight {
     std::string id;
     size_t index;
@@ -45,7 +39,6 @@ namespace gen {
   protected:
     std::string model_;
     std::vector<ParsedWeight> parsedWeights_;
-    const std::vector<PdfSetInfo> pdfSetsInfo;
     std::map<std::string, std::string> currWeightAttributeMap_;
     std::map<std::string, std::string> currGroupAttributeMap_;
     edm::OwnVector<gen::WeightGroupInfo> weightGroups_;
@@ -58,7 +51,6 @@ namespace gen {
     void updatePdfInfo(const ParsedWeight& weight);
     void updatePdfInfo(int lhaid, int index);
     void splitPdfGroups();
-    std::vector<PdfSetInfo> setupPdfSetsInfo();
     std::string searchAttributes(const std::string& label, const ParsedWeight& weight) const;
     std::string searchAttributesByTag(const std::string& label, const ParsedWeight& weight) const;
     std::string searchAttributesByRegex(const std::string& label, const ParsedWeight& weight) const;

--- a/GeneratorInterface/Core/interface/WeightHelper.h
+++ b/GeneratorInterface/Core/interface/WeightHelper.h
@@ -48,7 +48,7 @@ namespace gen {
     bool isOrphanPdfWeightGroup(ParsedWeight& weight);
     void updateScaleInfo(const ParsedWeight& weight);
     void updatePdfInfo(const ParsedWeight& weight);
-    void splitPdfGroups();
+
     int getLhapdfId(const ParsedWeight& weight);
     std::string searchAttributes(const std::string& label, const ParsedWeight& weight) const;
     std::string searchAttributesByTag(const std::string& label, const ParsedWeight& weight) const;

--- a/GeneratorInterface/Core/interface/WeightHelper.h
+++ b/GeneratorInterface/Core/interface/WeightHelper.h
@@ -48,6 +48,7 @@ namespace gen {
     bool isOrphanPdfWeightGroup(ParsedWeight& weight);
     void updateScaleInfo(const ParsedWeight& weight);
     void updatePdfInfo(const ParsedWeight& weight);
+    void cleanupOrphanCentralWeight();
 
     int getLhapdfId(const ParsedWeight& weight);
     std::string searchAttributes(const std::string& label, const ParsedWeight& weight) const;

--- a/GeneratorInterface/Core/src/LHEWeightHelper.cc
+++ b/GeneratorInterface/Core/src/LHEWeightHelper.cc
@@ -149,6 +149,7 @@ namespace gen {
       else if (group.weightType() == gen::WeightType::kPdfWeights)
         updatePdfInfo(weight);
     }
+    cleanupOrphanCentralWeight();
     // checks
     for (auto& wgt : weightGroups_) {
       if (!wgt.isWellFormed())

--- a/GeneratorInterface/Core/src/LHEWeightHelper.cc
+++ b/GeneratorInterface/Core/src/LHEWeightHelper.cc
@@ -149,7 +149,6 @@ namespace gen {
       else if (group.weightType() == gen::WeightType::kPdfWeights)
         updatePdfInfo(weight);
     }
-    //splitPdfGroups();
     // checks
     for (auto& wgt : weightGroups_) {
       if (!wgt.isWellFormed())

--- a/GeneratorInterface/Core/src/LHEWeightHelper.cc
+++ b/GeneratorInterface/Core/src/LHEWeightHelper.cc
@@ -167,6 +167,19 @@ namespace gen {
         std::cout << wgtScale.muR05muF1Index() << " ";
         std::cout << wgtScale.muR05muF2Index() << " ";
         std::cout << wgtScale.muR05muF05Index() << " \n";
+        for (auto name : wgtScale.getDynNames()) {
+          std::cout << name << ": ";
+          std::cout << wgtScale.getScaleIndex(1.0, 1.0, name) << " ";
+          std::cout << wgtScale.getScaleIndex(1.0, 2.0, name) << " ";
+          std::cout << wgtScale.getScaleIndex(1.0, 0.5, name) << " ";
+          std::cout << wgtScale.getScaleIndex(2.0, 1.0, name) << " ";
+          std::cout << wgtScale.getScaleIndex(2.0, 2.0, name) << " ";
+          std::cout << wgtScale.getScaleIndex(2.0, 0.5, name) << " ";
+          std::cout << wgtScale.getScaleIndex(0.5, 1.0, name) << " ";
+          std::cout << wgtScale.getScaleIndex(0.5, 2.0, name) << " ";
+          std::cout << wgtScale.getScaleIndex(0.5, 0.5, name) << "\n";
+        }
+
       } else if (wgt.weightType() == gen::WeightType::kPdfWeights) {
         std::cout << wgt.description() << "\n";
       }

--- a/GeneratorInterface/Core/src/LHEWeightHelper.cc
+++ b/GeneratorInterface/Core/src/LHEWeightHelper.cc
@@ -60,6 +60,10 @@ namespace gen {
         if (groupName.empty()) {
           throw std::runtime_error("couldn't find groupname");
         }
+        // May remove this, very specific error
+        if (groupName.find(".") != std::string::npos)
+          groupName.erase(groupName.find("."), groupName.size());
+
         for (auto* inner = e->FirstChildElement("weight"); inner != nullptr;
              inner = inner->NextSiblingElement("weight")) {
           // we are here if there is a weight in a weightgroup

--- a/GeneratorInterface/Core/src/LHEWeightHelper.cc
+++ b/GeneratorInterface/Core/src/LHEWeightHelper.cc
@@ -134,15 +134,22 @@ namespace gen {
         currentGroupIdx = weight.wgtGroup_idx;
       }
 
+      // split PDF groups
+      if (weightGroups_.back().weightType() == gen::WeightType::kPdfWeights) {
+        auto& pdfGroup = dynamic_cast<gen::PdfWeightGroupInfo&>(weightGroups_.back());
+        int lhaid = getLhapdfId(weight);
+        if (lhaid > 0 && !pdfGroup.isIdInParentSet(lhaid) && pdfGroup.getParentLhapdfId() > 0) {
+          weightGroups_.push_back(*buildGroup(weight));
+        }
+      }
       WeightGroupInfo& group = weightGroups_.back();
-
       group.addContainedId(weight.index, weight.id, weight.content);
       if (group.weightType() == gen::WeightType::kScaleWeights)
         updateScaleInfo(weight);
       else if (group.weightType() == gen::WeightType::kPdfWeights)
         updatePdfInfo(weight);
     }
-    splitPdfGroups();
+    //splitPdfGroups();
     // checks
     for (auto& wgt : weightGroups_) {
       if (!wgt.isWellFormed())

--- a/GeneratorInterface/Core/src/WeightHelper.cc
+++ b/GeneratorInterface/Core/src/WeightHelper.cc
@@ -117,13 +117,10 @@ namespace gen {
   void WeightHelper::updatePdfInfo(const ParsedWeight& weight) {
     auto& pdfGroup = dynamic_cast<gen::PdfWeightGroupInfo&>(weightGroups_.back());
     int lhaid = getLhapdfId(weight);
-    pdfGroup.addLhaid(lhaid);
-
     if (pdfGroup.getParentLhapdfId() < 0) {
       int parentId = lhaid - LHAPDF::lookupPDF(lhaid).second;
-      pdfGroup.setParentLhapdfId(parentId);
+      pdfGroup.setParentLhapdfInfo(parentId);
       pdfGroup.setUncertaintyType(gen::kUnknownUnc);
-      //pdfGroup.setName(LHAPDF::lookupPDF(parentId).first);
 
       std::string description = "";
       if (pdfGroup.uncertaintyType() == gen::kHessianUnc)
@@ -136,6 +133,8 @@ namespace gen {
 
       pdfGroup.appendDescription(description);
     }
+    // after setup parent info, add lhaid
+    pdfGroup.addLhaid(lhaid);
   }
 
   // TODO: Could probably recycle this code better

--- a/GeneratorInterface/Core/src/WeightHelper.cc
+++ b/GeneratorInterface/Core/src/WeightHelper.cc
@@ -43,6 +43,7 @@ namespace gen {
         return true;
       }
     } catch (...) {
+      return false;
     }
     return false;
   }
@@ -71,7 +72,7 @@ namespace gen {
     auto& content = weight.content;
     std::smatch match;
     for (const auto& lab : attributeNames_.at(label)) {
-      std::regex expr(lab + "\\s?=\\s?([0-9.]+(?:[eE][+-]?[0-9]+)?)");
+      std::regex expr(lab + "\\s?=\\s*([0-9.]+(?:[eE][+-]?[0-9]+)?)");
       if (std::regex_search(content, match, expr)) {
         return boost::algorithm::trim_copy(match.str(1));
       }
@@ -116,8 +117,17 @@ namespace gen {
         return;
       }
       updatePdfInfo(lhaid, weight.index);
-    } else
+    } else {
+      //auto& pdfGroup = dynamic_cast<gen::PdfWeightGroupInfo&>(group);
+      std::string groupName = group.headerEntry();
+      auto pdfInfo = std::find_if(pdfSetsInfo.begin(), pdfSetsInfo.end(), [groupName](const PdfSetInfo& setInfo) {
+        return setInfo.name == groupName;
+      });
+      lhaid = pdfInfo->lhapdfId + weight.index - group.firstId();
+      updatePdfInfo(lhaid, weight.index);
+      // debateable if we want to call it "wellformed"
       group.setIsWellFormed(false);
+    }
   }
 
   void WeightHelper::updatePdfInfo(int lhaid, int index) {

--- a/SimDataFormats/GeneratorProducts/interface/PdfWeightGroupInfo.h
+++ b/SimDataFormats/GeneratorProducts/interface/PdfWeightGroupInfo.h
@@ -22,7 +22,9 @@ namespace gen {
     int alphasUpIndex_;
     int alphasDownIndex_;
     int parentLhapdfId_ = -1;
-    std::vector<int> lhaids;
+    size_t parentLhapdfSize_ = -1;
+    std::string parentLhapdfError_;
+    std::vector<int> lhaids_;
     int parentLhapdfId(int lhaid) const { return lhaid - LHAPDF::lookupPDF(lhaid).second; }
 
   public:
@@ -42,12 +44,12 @@ namespace gen {
     void setAlphasDownIndex(int alphasDownIndex) { alphasDownIndex_ = alphasDownIndex; }
     PdfUncertaintyType uncertaintyType() const { return uncertaintyType_; }
     bool hasAlphasVariations() const { return hasAlphasVars_; }
-    void addLhaid(int lhaid) { lhaids.push_back(lhaid); }
-    std::vector<int>& getLhaIds() { return lhaids; }
+    void addLhaid(int lhaid);
+    std::vector<int>& getLhaIds() { return lhaids_; }
 
     bool isIdInParentSet(int lhaid) const { return parentLhapdfId_ == parentLhapdfId(lhaid); }
     int getParentLhapdfId() const { return parentLhapdfId_; }
-    void setParentLhapdfId(int lhaid) { parentLhapdfId_ = lhaid; }
+    void setParentLhapdfInfo(int lhaid);
 
     // need to remove
     bool containsLhapdfId(int lhaid) const { return isIdInParentSet(lhaid); }

--- a/SimDataFormats/GeneratorProducts/interface/ScaleWeightGroupInfo.h
+++ b/SimDataFormats/GeneratorProducts/interface/ScaleWeightGroupInfo.h
@@ -10,7 +10,8 @@ namespace gen {
   private:
     bool isFunctionalFormVar_;
     std::vector<size_t> muIndices_;
-
+    bool containsCentral_ = false;
+    int lhaid_ = -1;
     // Dyn_scale
     std::vector<std::string> dynNames_;
     std::vector<std::vector<size_t>> dynVec_;
@@ -32,11 +33,13 @@ namespace gen {
     virtual ~ScaleWeightGroupInfo() override {}
     void copy(const ScaleWeightGroupInfo& other);
     virtual ScaleWeightGroupInfo* clone() const override;
+    bool containsCentralWeight() const { return containsCentral_; }
 
     void setMuRMuFIndex(
         int globalIndex, std::string id, float muR, float muF, size_t dynNum = -1, std::string dynName = "");
     void addContainedId(int weightEntry, std::string id, std::string label, float muR, float muF);
-
+    int getLhaid() { return lhaid_; }
+    void setLhaid(int lhaid) { lhaid_ = lhaid; }
     // Is a variation of the functional form of the dynamic scale
     bool isFunctionalFormVariation();
     void setIsFunctionalFormVariation(bool functionalVar) { isFunctionalFormVar_ = functionalVar; }

--- a/SimDataFormats/GeneratorProducts/interface/ScaleWeightGroupInfo.h
+++ b/SimDataFormats/GeneratorProducts/interface/ScaleWeightGroupInfo.h
@@ -12,16 +12,18 @@ namespace gen {
     std::vector<size_t> muIndices_;
 
     // Dyn_scale
-    // bool hasDyn = false;
-    // Maybe have mapping of [muR##muF##index] = vector<dyn_scale_indices>
-    // std::unordered_map<size_t, std::vector<size_t>> dynMap;
+    std::vector<std::string> dynNames_;
+    std::vector<std::vector<size_t>> dynVec_;
+
     void setMuRMuFIndex(WeightMetaInfo& info, float muR, float muF);
+    void setMuRMuFIndex(WeightMetaInfo& info, float muR, float muF, size_t dynNum, std::string dynName);
     inline int getIndex(int muR, int muF) const { return 3 * muR + muF; }
     inline bool isValidValue(float mu) const { return mu == 0.5 || mu == 1.0 || mu == 2.0; }
 
   public:
     ScaleWeightGroupInfo() : ScaleWeightGroupInfo("") {}
-    ScaleWeightGroupInfo(std::string header, std::string name) : WeightGroupInfo(header, name), muIndices_(9) {
+    ScaleWeightGroupInfo(std::string header, std::string name)
+        : WeightGroupInfo(header, name), muIndices_(9, -1), dynVec_(9) {
       weightType_ = WeightType::kScaleWeights;
       isFunctionalFormVar_ = false;
     }
@@ -31,7 +33,8 @@ namespace gen {
     void copy(const ScaleWeightGroupInfo& other);
     virtual ScaleWeightGroupInfo* clone() const override;
 
-    void setMuRMuFIndex(int globalIndex, std::string id, float muR, float muF);
+    void setMuRMuFIndex(
+        int globalIndex, std::string id, float muR, float muF, size_t dynNum = -1, std::string dynName = "");
     void addContainedId(int weightEntry, std::string id, std::string label, float muR, float muF);
 
     // Is a variation of the functional form of the dynamic scale
@@ -46,6 +49,24 @@ namespace gen {
     size_t muR05muF05Index() const { return muIndices_.at(0); }
     size_t muR05muF1Index() const { return muIndices_.at(1); }
     size_t muR05muF2Index() const { return muIndices_.at(2); }
+    // dynweight version
+    size_t centralIndex(std::string& dynName) const { return getScaleIndex(4, dynName); }
+    size_t muR1muF2Index(std::string& dynName) const { return getScaleIndex(5, dynName); }
+    size_t muR1muF05Index(std::string& dynName) const { return getScaleIndex(3, dynName); }
+    size_t muR2muF05Index(std::string& dynName) const { return getScaleIndex(6, dynName); }
+    size_t muR2muF1Index(std::string& dynName) const { return getScaleIndex(7, dynName); }
+    size_t muR2muF2Index(std::string& dynName) const { return getScaleIndex(8, dynName); }
+    size_t muR05muF05Index(std::string& dynName) const { return getScaleIndex(0, dynName); }
+    size_t muR05muF1Index(std::string& dynName) const { return getScaleIndex(1, dynName); }
+    size_t muR05muF2Index(std::string& dynName) const { return getScaleIndex(2, dynName); }
+
+    size_t getScaleIndex(float muR, float muF, size_t dynNum) const;
+    size_t getScaleIndex(float muR, float muF, std::string& dynName) const;
+    size_t getScaleIndex(int index, std::string& dynName) const;
+    size_t getScaleIndex(float muR, float muF) const;
+
+    size_t getScaleIndex(int index, size_t dynNum) const { return dynVec_.at(index).at(dynNum); }
+    std::vector<std::string> getDynNames() const;
   };
 }  // namespace gen
 

--- a/SimDataFormats/GeneratorProducts/interface/ScaleWeightGroupInfo.h
+++ b/SimDataFormats/GeneratorProducts/interface/ScaleWeightGroupInfo.h
@@ -3,40 +3,27 @@
 
 #include "SimDataFormats/GeneratorProducts/interface/WeightGroupInfo.h"
 #include <unordered_map>
+#include <vector>
 
 namespace gen {
   class ScaleWeightGroupInfo : public WeightGroupInfo {
   private:
     bool isFunctionalFormVar_;
-    size_t centralIndex_;
-    size_t muR1muF2Index_;
-    size_t muR1muF05Index_;
-    size_t muR2muF05Index_;
-    size_t muR2muF1Index_;
-    size_t muR2muF2Index_;
-    size_t muR05muF05Index_;
-    size_t muR05muF1Index_;
-    size_t muR05muF2Index_;
+    std::vector<size_t> muIndices_;
+
     // Dyn_scale
     // bool hasDyn = false;
     // Maybe have mapping of [muR##muF##index] = vector<dyn_scale_indices>
     // std::unordered_map<size_t, std::vector<size_t>> dynMap;
+    void setMuRMuFIndex(WeightMetaInfo& info, float muR, float muF);
+    inline int getIndex(int muR, int muF) const { return 3 * muR + muF; }
+    inline bool isValidValue(float mu) const { return mu == 0.5 || mu == 1.0 || mu == 2.0; }
 
   public:
     ScaleWeightGroupInfo() : ScaleWeightGroupInfo("") {}
-    ScaleWeightGroupInfo(std::string header, std::string name) : WeightGroupInfo(header, name) {
+    ScaleWeightGroupInfo(std::string header, std::string name) : WeightGroupInfo(header, name), muIndices_(9) {
       weightType_ = WeightType::kScaleWeights;
       isFunctionalFormVar_ = false;
-      centralIndex_ = 0;
-      muR1muF2Index_ = 0;
-      muR1muF05Index_ = 0;
-      muR2muF05Index_ = 0;
-      muR2muF1Index_ = 0;
-      muR2muF2Index_ = 0;
-      muR2muF05Index_ = 0;
-      muR05muF05Index_ = 0;
-      muR05muF1Index_ = 0;
-      muR05muF2Index_ = 0;
     }
     ScaleWeightGroupInfo(std::string header) : ScaleWeightGroupInfo(header, header) {}
     ScaleWeightGroupInfo(const ScaleWeightGroupInfo& other) { copy(other); }
@@ -44,22 +31,21 @@ namespace gen {
     void copy(const ScaleWeightGroupInfo& other);
     virtual ScaleWeightGroupInfo* clone() const override;
 
-    void setMuRMuFIndex(WeightMetaInfo& info, float muR, float muF);
     void setMuRMuFIndex(int globalIndex, std::string id, float muR, float muF);
     void addContainedId(int weightEntry, std::string id, std::string label, float muR, float muF);
 
     // Is a variation of the functional form of the dynamic scale
     bool isFunctionalFormVariation();
     void setIsFunctionalFormVariation(bool functionalVar) { isFunctionalFormVar_ = functionalVar; }
-    size_t centralIndex() const { return centralIndex_; }
-    size_t muR1muF2Index() const { return muR1muF2Index_; }
-    size_t muR1muF05Index() const { return muR1muF05Index_; }
-    size_t muR2muF05Index() const { return muR2muF05Index_; }
-    size_t muR2muF1Index() const { return muR2muF1Index_; }
-    size_t muR2muF2Index() const { return muR2muF2Index_; }
-    size_t muR05muF05Index() const { return muR05muF05Index_; }
-    size_t muR05muF1Index() const { return muR05muF1Index_; }
-    size_t muR05muF2Index() const { return muR05muF2Index_; }
+    size_t centralIndex() const { return muIndices_.at(4); }
+    size_t muR1muF2Index() const { return muIndices_.at(5); }
+    size_t muR1muF05Index() const { return muIndices_.at(3); }
+    size_t muR2muF05Index() const { return muIndices_.at(6); }
+    size_t muR2muF1Index() const { return muIndices_.at(7); }
+    size_t muR2muF2Index() const { return muIndices_.at(8); }
+    size_t muR05muF05Index() const { return muIndices_.at(0); }
+    size_t muR05muF1Index() const { return muIndices_.at(1); }
+    size_t muR05muF2Index() const { return muIndices_.at(2); }
   };
 }  // namespace gen
 

--- a/SimDataFormats/GeneratorProducts/interface/WeightGroupInfo.h
+++ b/SimDataFormats/GeneratorProducts/interface/WeightGroupInfo.h
@@ -42,8 +42,9 @@ namespace gen {
   public:
     WeightGroupInfo() : WeightGroupInfo("") {}
     WeightGroupInfo(std::string header, std::string name)
-        : headerEntry_(header), name_(name), firstId_(-1), lastId_(-1) {}
-    WeightGroupInfo(std::string header) : headerEntry_(header), name_(header), firstId_(-1), lastId_(-1) {}
+        : isWellFormed_(true), headerEntry_(header), name_(name), firstId_(-1), lastId_(-1) {}
+    WeightGroupInfo(std::string header)
+        : isWellFormed_(true), headerEntry_(header), name_(header), firstId_(-1), lastId_(-1) {}
     WeightGroupInfo(const WeightGroupInfo& other) { copy(other); }
     WeightGroupInfo& operator=(const WeightGroupInfo& other) {
       copy(other);

--- a/SimDataFormats/GeneratorProducts/src/PdfWeightGroupInfo.cc
+++ b/SimDataFormats/GeneratorProducts/src/PdfWeightGroupInfo.cc
@@ -6,7 +6,7 @@ namespace gen {
     hasAlphasVars_ = other.hasAlphasVariations();
     alphasUpIndex_ = other.alphasDownIndex();
     alphasDownIndex_ = other.alphasDownIndex();
-    lhapdfIdsContained_ = other.lhapdfIdsContained_;
+    parentLhapdfId_ = other.getParentLhapdfId();
     WeightGroupInfo::copy(other);
   }
 

--- a/SimDataFormats/GeneratorProducts/src/PdfWeightGroupInfo.cc
+++ b/SimDataFormats/GeneratorProducts/src/PdfWeightGroupInfo.cc
@@ -11,4 +11,19 @@ namespace gen {
   }
 
   PdfWeightGroupInfo* PdfWeightGroupInfo::clone() const { return new PdfWeightGroupInfo(*this); }
+  void PdfWeightGroupInfo::addLhaid(int lhaid) {
+    lhaids_.push_back(lhaid);
+    if (lhaids_.size() == parentLhapdfSize_)
+      setIsWellFormed(true);
+    else
+      setIsWellFormed(false);
+  }
+
+  void PdfWeightGroupInfo::setParentLhapdfInfo(int lhaid) {
+    parentLhapdfId_ = lhaid;
+    LHAPDF::PDFSet pdfSet(LHAPDF::lookupPDF(lhaid).first);
+    parentLhapdfSize_ = pdfSet.size();
+    parentLhapdfError_ = pdfSet.errorType();
+  }
+
 }  // namespace gen

--- a/SimDataFormats/GeneratorProducts/src/ScaleWeightGroupInfo.cc
+++ b/SimDataFormats/GeneratorProducts/src/ScaleWeightGroupInfo.cc
@@ -13,6 +13,17 @@ namespace gen {
   ScaleWeightGroupInfo* ScaleWeightGroupInfo::clone() const { return new ScaleWeightGroupInfo(*this); }
 
   void ScaleWeightGroupInfo::addContainedId(int globalIndex, std::string id, std::string label, float muR, float muF) {
+    int idxDiff = firstId_ - globalIndex;
+    if (idxDiff > 0) {
+      for (auto& entry : muIndices_) {
+        entry += idxDiff;
+      }
+      for (auto& subVec : dynVec_) {
+        for (auto& entry : subVec) {
+          entry += idxDiff;
+        }
+      }
+    }
     WeightGroupInfo::addContainedId(globalIndex, id, label);
     setMuRMuFIndex(globalIndex, id, muR, muF);
   }
@@ -32,6 +43,8 @@ namespace gen {
       isWellFormed_ = false;
       return;
     }
+    if (index == 4)
+      containsCentral_ = true;
     muIndices_[index] = info.localIndex;
   }
 

--- a/SimDataFormats/GeneratorProducts/src/ScaleWeightGroupInfo.cc
+++ b/SimDataFormats/GeneratorProducts/src/ScaleWeightGroupInfo.cc
@@ -4,15 +4,7 @@
 
 namespace gen {
   void ScaleWeightGroupInfo::copy(const ScaleWeightGroupInfo& other) {
-    centralIndex_ = other.centralIndex_;
-    muR1muF2Index_ = other.muR1muF2Index_;
-    muR1muF05Index_ = other.muR1muF05Index_;
-    muR2muF05Index_ = other.muR2muF05Index_;
-    muR2muF1Index_ = other.muR2muF1Index_;
-    muR2muF2Index_ = other.muR2muF2Index_;
-    muR05muF05Index_ = other.muR2muF05Index_;
-    muR05muF1Index_ = other.muR05muF1Index_;
-    muR05muF2Index_ = other.muR05muF2Index_;
+    muIndices_ = other.muIndices_;
     WeightGroupInfo::copy(other);
   }
 
@@ -29,25 +21,10 @@ namespace gen {
   }
 
   void ScaleWeightGroupInfo::setMuRMuFIndex(WeightMetaInfo& info, float muR, float muF) {
-    if (muR == 0.5 && muF == 0.5)
-      muR05muF05Index_ = info.localIndex;
-    else if (muR == 0.5 && muF == 1.0)
-      muR05muF1Index_ = info.localIndex;
-    else if (muR == 0.5 && muF == 2.0)
-      muR05muF2Index_ = info.localIndex;
-    else if (muR == 1.0 && muF == 0.5)
-      muR1muF05Index_ = info.localIndex;
-    else if (muR == 1.0 && muF == 1.0)
-      centralIndex_ = info.localIndex;
-    else if (muR == 1.0 && muF == 2.0)
-      muR1muF2Index_ = info.localIndex;
-    else if (muR == 2.0 && muF == 0.5)
-      muR2muF05Index_ = info.localIndex;
-    else if (muR == 2.0 && muF == 1.0)
-      muR2muF1Index_ = info.localIndex;
-    else if (muR == 2.0 && muF == 2.0)
-      muR2muF2Index_ = info.localIndex;
-    else
+    int index = getIndex(muR, muF);
+    if (index < 0 || index > 8 || !(isValidValue(muR) && isValidValue(muF))) {
       isWellFormed_ = false;
+    }
+    muIndices_[index] = info.localIndex;
   }
 }  // namespace gen

--- a/SimDataFormats/GeneratorProducts/src/ScaleWeightGroupInfo.cc
+++ b/SimDataFormats/GeneratorProducts/src/ScaleWeightGroupInfo.cc
@@ -5,6 +5,8 @@
 namespace gen {
   void ScaleWeightGroupInfo::copy(const ScaleWeightGroupInfo& other) {
     muIndices_ = other.muIndices_;
+    dynVec_ = other.dynVec_;
+    dynNames_ = other.dynNames_;
     WeightGroupInfo::copy(other);
   }
 
@@ -15,16 +17,82 @@ namespace gen {
     setMuRMuFIndex(globalIndex, id, muR, muF);
   }
 
-  void ScaleWeightGroupInfo::setMuRMuFIndex(int globalIndex, std::string id, float muR, float muF) {
+  void ScaleWeightGroupInfo::setMuRMuFIndex(
+      int globalIndex, std::string id, float muR, float muF, size_t dynNum, std::string dynName) {
     auto metaInfo = weightMetaInfoByGlobalIndex(id, globalIndex);
-    setMuRMuFIndex(metaInfo, muR, muF);
+    if ((int)dynNum == -1)
+      setMuRMuFIndex(metaInfo, muR, muF);
+    else
+      setMuRMuFIndex(metaInfo, muR, muF, dynNum, dynName);
   }
 
   void ScaleWeightGroupInfo::setMuRMuFIndex(WeightMetaInfo& info, float muR, float muF) {
     int index = getIndex(muR, muF);
     if (index < 0 || index > 8 || !(isValidValue(muR) && isValidValue(muF))) {
       isWellFormed_ = false;
+      return;
     }
     muIndices_[index] = info.localIndex;
   }
+
+  void ScaleWeightGroupInfo::setMuRMuFIndex(
+      WeightMetaInfo& info, float muR, float muF, size_t dynNum, std::string dynName) {
+    int index = getIndex(muR, muF);
+    if (index < 0 || index > 8 || !(isValidValue(muR) && isValidValue(muF))) {
+      isWellFormed_ = false;
+      return;
+    }
+    // resize if too small
+    if (dynVec_.at(index).size() < dynNum + 1) {
+      for (auto& dynIt : dynVec_)
+        dynIt.resize(dynNum + 1);
+      dynNames_.resize(dynNum + 1);
+    }
+
+    if (dynNames_.at(dynNum).empty())
+      dynNames_[dynNum] = dynName;
+    dynVec_[index][dynNum] = info.localIndex;
+  }
+
+  size_t ScaleWeightGroupInfo::getScaleIndex(float muR, float muF, std::string& dynName) const {
+    auto it = std::find(dynNames_.begin(), dynNames_.end(), dynName);
+    if (it == dynNames_.end())
+      return -1;
+    else
+      return getScaleIndex(muR, muF, it - dynNames_.begin());
+  }
+  size_t ScaleWeightGroupInfo::getScaleIndex(int index, std::string& dynName) const {
+    auto it = std::find(dynNames_.begin(), dynNames_.end(), dynName);
+    if (it == dynNames_.end())
+      return -1;
+    else
+      return getScaleIndex(index, it - dynNames_.begin());
+  }
+
+  size_t ScaleWeightGroupInfo::getScaleIndex(float muR, float muF, size_t dynNum) const {
+    int index = getIndex(muR, muF);
+    if (index < 0 || index > 8 || !(isValidValue(muR) && isValidValue(muF)) || dynNum + 1 > dynNames_.size()) {
+      // Bad access!
+      return -1;
+    }
+    return getScaleIndex(index, dynNum);
+  }
+  size_t ScaleWeightGroupInfo::getScaleIndex(float muR, float muF) const {
+    int index = getIndex(muR, muF);
+    if (index < 0 || index > 8 || !(isValidValue(muR) && isValidValue(muF))) {
+      // Bad access!
+      return -1;
+    }
+    return muIndices_.at(index);
+  }
+
+  std::vector<std::string> ScaleWeightGroupInfo::getDynNames() const {
+    std::vector<std::string> returnVec;
+    for (auto item : dynNames_) {
+      if (!item.empty())
+        returnVec.push_back(item);
+    }
+    return returnVec;
+  }
+
 }  // namespace gen


### PR DESCRIPTION
## PR description:
Fixing final issues with the parsing code. Here is a checklist of what this PR will hope to do:
- [x] Fix parsing issues where parsing breaks 
- [ ] Check that all LHE test files are parsed in the desired way
- [ ] Check the parsing code running over miniAOD -> NanoAOD 

### Limitations:
There are some noticed problems.
- For Scale weights, the first (central) scale weight is sometimes not included in the "scaleWeight" group. This happens often enough that it might be worth it to implement a fix
```xml
<weightgroup name="NNPDF31_nnlo_hessian_pdfas" combine="symmhessian+as"> 
    <weight id="1001" MUR="1.0" MUF="1.0" PDF="306000" >  </weight>
</weightgroup> 
<weightgroup name="Central scale variation" combine="envelope">
    <weight id="1002" MUR="2.0" MUF="1.0" PDF="306000" > MUR=2.0  </weight>
    <weight id="1003" MUR="0.5" MUF="1.0" PDF="306000" > MUR=0.5  </weight>
    <weight id="1004" MUR="1.0" MUF="2.0" PDF="306000" > MUF=2.0  </weight>
    <weight id="1005" MUR="2.0" MUF="2.0" PDF="306000" > MUR=2.0 MUF=2.0  </weight>
    <weight id="1006" MUR="0.5" MUF="2.0" PDF="306000" > MUR=0.5 MUF=2.0  </weight>
    <weight id="1007" MUR="1.0" MUF="0.5" PDF="306000" > MUF=0.5  </weight>
    <weight id="1008" MUR="2.0" MUF="0.5" PDF="306000" > MUR=2.0 MUF=0.5  </weight>
    <weight id="1009" MUR="0.5" MUF="0.5" PDF="306000" > MUR=0.5 MUF=0.5  </weight>
</weightgroup> 
```
- For scale weights, currently DYN_Scale weights are totally ignored. It would be nice to work towards adding that, but input would be good
- The current code uses LHAPDF library to get LHA info, but this doesn't grab uncertainty type. Right now, the code sets all the pdf uncertainties to `kUnknownUnc`.
- There are certain fixes put in place to handle specific errors in the test lhe files that will become outdated as the xml is cleaned before or standardized, and it could cause unintended behavior as more exotic xml files pop up. For instance, in one file, the group weights have `.LHgrid` appended to the pdfset name, so `MMHT2014lo68cl.LHgrid` is the seen pdf weight which can't be found by the pdfsetinfo. The current fix is to remove the substring after the `.`, but that could cause errors for groupnames that are supposed to have a `.` in them