### PR TITLE
Fix Orphan weight stuff

### DIFF
--- a/SimDataFormats/GeneratorProducts/src/WeightGroupInfo.cc
+++ b/SimDataFormats/GeneratorProducts/src/WeightGroupInfo.cc
@@ -59,28 +59,17 @@ namespace gen {
   void WeightGroupInfo::addContainedId(int weightEntry, std::string id, std::string label = "") {
     if (firstId_ == -1 || weightEntry < firstId_) {
       firstId_ = weightEntry;
-      // Reset to reflect that indices will be shifted
-      for (auto& entry : idsContained_)
+      for (auto& entry : idsContained_)  // Reset if indices need to be shifted
         entry.localIndex = entry.globalIndex - firstId_;
     }
     if (weightEntry > lastId_)
       lastId_ = weightEntry;
 
-    WeightMetaInfo info;
-    info.globalIndex = weightEntry;
-    info.localIndex = weightEntry - firstId_;
-    info.id = id;
-    info.label = label;
-
-    if (idsContained_.size() > info.localIndex) {
-      idsContained_.resize(lastId_ - firstId_);
-      idsContained_.insert(idsContained_.begin() + info.localIndex, info);
-    } else if (idsContained_.size() == info.localIndex) {
-      idsContained_.push_back(info);
-    } else {
-      idsContained_.resize(info.localIndex + 1);
-      idsContained_[info.localIndex] = info;
-    }
+    size_t localIndex = weightEntry - firstId_;
+    WeightMetaInfo info = {static_cast<size_t>(weightEntry), localIndex, id, label};
+    // logic to insert for all cases e.g. inserting in the middle of the vector
+    idsContained_.resize(lastId_ - firstId_);
+    idsContained_.insert(idsContained_.begin() + localIndex, info);
   }
 
   std::vector<WeightMetaInfo> WeightGroupInfo::containedIds() const { return idsContained_; }

--- a/SimDataFormats/GeneratorProducts/src/WeightGroupInfo.cc
+++ b/SimDataFormats/GeneratorProducts/src/WeightGroupInfo.cc
@@ -72,8 +72,8 @@ namespace gen {
     info.id = id;
     info.label = label;
 
-    if (idsContained_.size() < info.localIndex) {
-      idsContained_.resize(info.localIndex);
+    if (idsContained_.size() > info.localIndex) {
+      idsContained_.resize(lastId_ - firstId_);
       idsContained_.insert(idsContained_.begin() + info.localIndex, info);
     } else if (idsContained_.size() == info.localIndex) {
       idsContained_.push_back(info);


### PR DESCRIPTION
Fixed orphan weight issue. The orphaned central weight should have a local index of 0, but in teh logic, I assumed the weight would be larger (for some reason....) This fixes that problem so `/ZGToLLG_01J_5f_PDFWeights_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v2/MINIAODSIM` now runs without a hitch. Still to be decided if the results are what we expect, but at least there are no crashes

I want to squash the other commits that popped up, so don't merge until I fix that!