### PR TITLE
Add option for returning from LHEweight parsing if not valid xml

### DIFF
--- a/GeneratorInterface/Core/interface/LHEWeightHelper.h
+++ b/GeneratorInterface/Core/interface/LHEWeightHelper.h
@@ -24,9 +24,10 @@ namespace gen {
     void parseWeights();
     bool isConsistent();
     void swapHeaders();
-
+    void setFailIfInvalidXML(bool value) { failIfInvalidXML_ = value; }
   private:
     std::vector<std::string> headerLines_;
+    bool failIfInvalidXML_ = false;
   };
 }  // namespace gen
 

--- a/GeneratorInterface/Core/plugins/LHEWeightProductProducer.cc
+++ b/GeneratorInterface/Core/plugins/LHEWeightProductProducer.cc
@@ -57,6 +57,7 @@ LHEWeightProductProducer::LHEWeightProductProducer(const edm::ParameterSet& iCon
             [this](const std::string& tag) { return mayConsume<GenWeightInfoProduct, edm::InLumi>(tag); })) {
   produces<GenWeightProduct>();
   produces<GenWeightInfoProduct, edm::Transition::BeginLuminosityBlock>();
+  weightHelper_.setFailIfInvalidXML(iConfig.getUntrackedParameter<bool>("failIfInvalidXML", false));
 }
 
 LHEWeightProductProducer::~LHEWeightProductProducer() {}

--- a/GeneratorInterface/Core/src/LHEWeightHelper.cc
+++ b/GeneratorInterface/Core/src/LHEWeightHelper.cc
@@ -2,6 +2,7 @@
 #include <boost/algorithm/string/join.hpp>
 #include <boost/algorithm/string/replace.hpp>
 #include <iostream>
+#include <stdexcept>
 
 using namespace tinyxml2;
 
@@ -11,7 +12,11 @@ namespace gen {
   void LHEWeightHelper::parseWeights() {
     parsedWeights_.clear();
 
-    if (!isConsistent()) {
+    if (!isConsistent() && failIfInvalidXML_) {
+      throw std::runtime_error( "XML in LHE is not consistent: Most likely, tags were swapped.\n" \
+                                "To turn on fault fixing, use 'setFailIfInvalidXML(false)'\n" \
+                                "WARNING: the tag swapping may lead to weights associated with the incorrect group");
+    } else if (!isConsistent()) {
       swapHeaders();
     }
 
@@ -29,7 +34,10 @@ namespace gen {
     if (xmlError != 0) {
       std::cerr << "Error in lhe xml file" << std::endl;
       xmlDoc.PrintError();
-      return;
+      if(failIfInvalidXML_)
+        throw std::runtime_error("XML is unreadable because of above error.");
+      else
+        return;
     }
 
     std::vector<std::string> nameAlts_ = {"name", "type"};

--- a/GeneratorInterface/Core/test/testGenWeightProducer_cfg.py
+++ b/GeneratorInterface/Core/test/testGenWeightProducer_cfg.py
@@ -26,8 +26,9 @@ process.out = cms.OutputModule("PoolOutputModule",
                 'keep GenWeightInfoProduct_test*Weights*_*_*',])
 )
 
-#process.testLHEWeights = cms.EDProducer("LHEWeightProductProducer",
-#    lheSourceLabel = cms.string("externalLHEProducer"))
+# process.testLHEWeights = cms.EDProducer("LHEWeightProductProducer",
+#    lheSourceLabel = cms.string("externalLHEProducer"),
+#    failIfValidXML = cms.untracked.bool(True))
 
 process.testGenWeights = cms.EDProducer("GenWeightProductProducer",
     genInfo = cms.InputTag("generator"),

--- a/PhysicsTools/NanoAOD/python/nanogen_cff.py
+++ b/PhysicsTools/NanoAOD/python/nanogen_cff.py
@@ -11,7 +11,8 @@ genWeights = cms.EDProducer("GenWeightProductProducer",
     genLumiInfoHeader = cms.InputTag("generator"))
 
 lheWeights = cms.EDProducer("LHEWeightProductProducer",
-    lheSourceLabels = cms.vstring(["externalLHEProducer", "source"])
+    lheSourceLabels = cms.vstring(["externalLHEProducer", "source"]),
+    failIfInvalidXML = cms.untracked.bool(True)
     #lheWeightSourceLabels = cms.vstring(["externalLHEProducer", "source"])
 )
 


### PR DESCRIPTION
# Overview
Setter function with variable to decide if to fail if XML is not valid

## Limitations
This only is checking if the xml fails the `isConsistent` function which checks if the XML has swapped tags (ie the tags are each at the right level). This can be expanded if needed (the other check done on the XML is if &gt; is used in lieu of >, but that seems fairly trivial). 

Also, the error handling is not very fleshed out. It prints off a stock error message to `cerr` (is there a CMSSW error logging functionality or?) and just returns, so the code does not fail. If we want to have the code fail more upstream, we could change the parsing function to return a bool with the status of the parsing. 