### PR TITLE
Psweight fix

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
@@ -983,6 +983,7 @@ public:
         } else if (line == "Baseline") {
           weightChoice->psBaselineID = weightIter;
         } else if (line.find("isr") != std::string::npos || line.find("fsr") != std::string::npos) {
+          weightChoice->matchPS_alt = line.find("sr:") != std::string::npos;  // (f/i)sr: for new weights
           if (keepAllPSWeights_) {
             weightChoice->psWeightIDs.push_back(weightIter);  // PS variations
           } else if (std::regex_search(line, groups, mainPSw)) {
@@ -991,7 +992,6 @@ public:
             int psIdx = (line.find("fsr") != std::string::npos) ? 1 : 0;
             psIdx += (groups.str(2) == "Hi" || groups.str(2) == "_up" || groups.str(2) == "2.0") ? 0 : 2;
             weightChoice->psWeightIDs[psIdx] = weightIter;
-            weightChoice->matchPS_alt = (weightChoice->defPSWeightIDs_alt[psIdx] == weightIter);
           }
         }
         weightIter++;


### PR DESCRIPTION
## Overview
This PR is to expand the filling of Parton Shower weights. This is covered in the [issue talked about here](https://github.com/cms-nanoAOD/cmssw/issues/546)
In principle, the fix allows for adding madgraph genlevel weights that have a different format (ie `fsr:murfact=0.5` instead of `fsrDefLow`). This only matters if the `keepAllPSWeights` is False since keeping all the weights, all that matters is it is a PS weight (ie there is isr or fsr in the name).

### Complication
There is a canonical order for the main PS weights, but some files can have LHE weights in the genHeader, so have the flexibility is important. The first commit (4d4ea44) simply adds parsing for the different style weights.

A complication comes from some Gen Headers being having problems in them. For example: `/ZGTo2NuG_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM` has names missing in the header. Because of this, the parsing will fail in finding all of weights. Commit 21eeea2 adds a fall back: if weights are missing, use the weights in the spots that make sense, ie (6,7,8,9) for the regular style, (27, 5, 26, 4) for the `fsr:murfact=0.5` style weights (this is for `[0] is ISR=2 FSR=1; [1] is ISR=1 FSR=2; [2] is ISR=0.5 FSR=1; [3] is ISR=1 FSR=0.5;`)

Commit c275752 does a refactor of the PSWeight filling since the PSWeights are parsed in the exact same way in 3 different spots.

Because of the complication, the code can probably be reduced, especially if it is always the case that once can use the "hardcoded" positions for weights (as above) whenever `getLHEweightsFromGenInfo` is false (defined here https://github.com/kdlong/cmssw/blob/c275752255e2c995878002fae32df868661dc162/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc#L310-313 ) 