### PR TITLE
Gen weight refactor main

### DIFF
--- a/GeneratorInterface/Core/interface/LHEWeightHelper.h
+++ b/GeneratorInterface/Core/interface/LHEWeightHelper.h
@@ -21,7 +21,7 @@ namespace gen {
   public:
     LHEWeightHelper() : WeightHelper(){};
 
-    enum ErrorType { SWAPHEADER, HTMLSTYLE, TRAILINGSTR, UNKNOWN };
+    enum class ErrorType { SwapHeader, HTMLStyle, TrailingStr, Unknown, NoError };
 
     void setHeaderLines(std::vector<std::string> headerLines);
     void parseWeights();
@@ -32,13 +32,14 @@ namespace gen {
   private:
     std::vector<std::string> headerLines_;
     std::string weightgroupKet_ = "</weightgroup>";
+    std::string weightTag_ = "</weight>";
     bool failIfInvalidXML_ = false;
     std::string parseGroupName(tinyxml2::XMLElement* el);
     void addGroup(tinyxml2::XMLElement* inner, std::string groupName, int groupIndex, int& weightIndex);
     bool parseLHE(tinyxml2::XMLDocument& xmlDoc);
     tinyxml2::XMLError tryReplaceHtmlStyle(tinyxml2::XMLDocument& xmlDoc, std::string& fullHeader);
     tinyxml2::XMLError tryRemoveTrailings(tinyxml2::XMLDocument& xmlDoc, std::string& fullHeader);
-    ErrorType findErrorType(std::string& fullHeader);
+    ErrorType findErrorType(int xmlError, std::string& fullHeader);
   };
 }  // namespace gen
 

--- a/GeneratorInterface/Core/interface/LHEWeightHelper.h
+++ b/GeneratorInterface/Core/interface/LHEWeightHelper.h
@@ -21,7 +21,7 @@ namespace gen {
   public:
     LHEWeightHelper() : WeightHelper(){};
 
-    enum class ErrorType { SwapHeader, HTMLStyle, TrailingStr, Unknown, NoError };
+    enum class ErrorType { Empty, SwapHeader, HTMLStyle, NoWeightGroup, TrailingStr, Unknown, NoError };
 
     void setHeaderLines(std::vector<std::string> headerLines);
     void parseWeights();

--- a/GeneratorInterface/Core/interface/WeightHelper.h
+++ b/GeneratorInterface/Core/interface/WeightHelper.h
@@ -47,6 +47,7 @@ namespace gen {
         std::unique_ptr<GenWeightProduct>& product, double weight, std::string name, int weightNum, int groupIndex);
     int findContainingWeightGroup(std::string wgtId, int weightIndex, int previousGroupIndex);
     void setDebug(bool value) { debug_ = value; }
+    bool fillEmptyIfWeightFails() { return fillEmptyIfWeightFails_; }
 
   protected:
     // TODO: Make this only print from one thread a la

--- a/GeneratorInterface/Core/interface/WeightHelper.h
+++ b/GeneratorInterface/Core/interface/WeightHelper.h
@@ -34,6 +34,7 @@ namespace gen {
     template <typename T>
     std::unique_ptr<GenWeightProduct> weightProduct(std::vector<T> weights, float w0);
 
+    void setfillEmptyIfWeightFails(bool value) { fillEmptyIfWeightFails_ = value; }
     void setModel(std::string model) { model_ = model; }
     void setGuessPSWeightIdx(bool guessPSWeightIdx) {
       PartonShowerWeightGroupInfo::setGuessPSWeightIdx(guessPSWeightIdx);
@@ -51,6 +52,7 @@ namespace gen {
     // TODO: Make this only print from one thread a la
     // https://github.com/kdlong/cmssw/blob/master/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc#L1069
     bool debug_ = false;
+    bool fillEmptyIfWeightFails_ = false;
     const unsigned int FIRST_PSWEIGHT_ENTRY = 2;
     const unsigned int DEFAULT_PSWEIGHT_LENGTH = 46;
     std::string model_;
@@ -103,11 +105,23 @@ namespace gen {
     // Just add an empty product (need for all cases or...?)
     if (weights.size() > 1) {
       for (const auto& weight : weights) {
-        if constexpr (std::is_same<T, gen::WeightsInfo>::value) {
-          weightGroupIndex = addWeightToProduct(weightProduct, weight.wgt, weight.id, i, weightGroupIndex);
+        try {
+          if constexpr (std::is_same<T, gen::WeightsInfo>::value) {
+            weightGroupIndex = addWeightToProduct(weightProduct, weight.wgt, weight.id, i, weightGroupIndex);
+          } else if (std::is_same<T, double>::value)
+            weightGroupIndex = addWeightToProduct(weightProduct, weight, std::to_string(i), i, weightGroupIndex);
+
+        } catch (cms::Exception& e) {
+          if (fillEmptyIfWeightFails_) {
+            std::cerr << "WARNING: " << e.what() << std::endl;
+            std::cerr << "fillEmptyIfWeightFails_ is set to True, so variations will be empty!!" << std::endl;
+            weightProduct->setNumWeightSets(1);  // Only central weight
+            return weightProduct;
+          } else {
+            throw cms::Exception("ERROR: " + std::string(e.what()) +
+                                 "\nfillEmptyIfWeightFails_ is set to False, so exiting code");
+          }
         }
-        else if (std::is_same<T, double>::value)
-          weightGroupIndex = addWeightToProduct(weightProduct, weight, std::to_string(i), i, weightGroupIndex);
         i++;
       }
     }

--- a/GeneratorInterface/Core/plugins/LHEWeightProductProducer.cc
+++ b/GeneratorInterface/Core/plugins/LHEWeightProductProducer.cc
@@ -58,6 +58,7 @@ LHEWeightProductProducer::LHEWeightProductProducer(const edm::ParameterSet& iCon
   produces<GenWeightProduct>();
   produces<GenWeightInfoProduct, edm::Transition::BeginLuminosityBlock>();
   weightHelper_.setFailIfInvalidXML(iConfig.getUntrackedParameter<bool>("failIfInvalidXML", false));
+  weightHelper_.setfillEmptyIfWeightFails(iConfig.getUntrackedParameter<bool>("fillEmptyIfWeightFails", false));
   weightHelper_.setDebug(iConfig.getUntrackedParameter<bool>("debug", false));
   weightHelper_.setGuessPSWeightIdx(iConfig.getUntrackedParameter<bool>("guessPSWeightIdx", false));
 }

--- a/GeneratorInterface/Core/src/LHEWeightHelper.cc
+++ b/GeneratorInterface/Core/src/LHEWeightHelper.cc
@@ -38,6 +38,14 @@ namespace gen {
         if (debug_)
           std::cout << "  >>> There is non-XML text at the end of this file\n";
         xmlError = tryRemoveTrailings(xmlDoc, fullHeader);
+      } else if (errorType == ErrorType::Empty) {
+        if (debug_)
+          std::cout << "  >>> There are no LHE xml header, ending parsing" << std::endl;
+        return false;
+      } else if (errorType == ErrorType::NoWeightGroup) {
+        if (debug_)
+          std::cout << "  >>> There are no <weightgroup> in the LHE xml header, ending parsing" << std::endl;
+        return false;
       } else {
         std::string error = "Fatal error when parsing the LHE header. The header is not valid XML! Parsing error was ";
         error += xmlDoc.ErrorStr();
@@ -171,11 +179,15 @@ namespace gen {
   }
 
   LHEWeightHelper::ErrorType LHEWeightHelper::findErrorType(int xmlError, std::string& fullHeader) {
-    if (!isConsistent())
+    if (fullHeader.size() == 0)
+      return ErrorType::Empty;
+    else if (!isConsistent())
       return ErrorType::SwapHeader;
     else if (fullHeader.find("&lt;") != std::string::npos || fullHeader.find("&gt;") != std::string::npos)
       return ErrorType::HTMLStyle;
     else if (xmlError != 0) {
+      if (fullHeader.rfind(weightgroupKet_) == std::string::npos)
+        return ErrorType::NoWeightGroup;
       std::string trailingCand =
           fullHeader.substr(fullHeader.rfind(weightgroupKet_) + std::string(weightgroupKet_).length());
       if (trailingCand.find('<') == std::string::npos || trailingCand.find('>') == std::string::npos)

--- a/GeneratorInterface/Core/src/LHEWeightHelper.cc
+++ b/GeneratorInterface/Core/src/LHEWeightHelper.cc
@@ -17,20 +17,20 @@ namespace gen {
     if (debug_)
       std::cout << "Full header is \n" << fullHeader << std::endl;
     int xmlError = xmlDoc.Parse(fullHeader.c_str());
-    ErrorType errorType = findErrorType(xmlError, fullHeader);
+    ErrorType errorType;
 
-    for (;errorType != ErrorType::NoError; errorType = findErrorType(xmlError, fullHeader)) {
+    while (errorType = findErrorType(xmlError, fullHeader), errorType != ErrorType::NoError) {
       if (failIfInvalidXML_) {
         xmlDoc.PrintError();
         throw cms::Exception("LHEWeightHelper")
-           << "The LHE header is not valid XML! Weight information was not properly parsed.";
+            << "The LHE header is not valid XML! Weight information was not properly parsed.";
       } else if (errorType == ErrorType::HTMLStyle) {
         if (debug_)
           std::cout << "  >>> This file uses &gt; instead of >\n";
         xmlError = tryReplaceHtmlStyle(xmlDoc, fullHeader);
       } else if (errorType == ErrorType::SwapHeader) {
         if (debug_)
-            std::cout << "  >>> Some headers in the file are swapped\n";
+          std::cout << "  >>> Some headers in the file are swapped\n";
         swapHeaders();
         fullHeader = boost::algorithm::join(headerLines_, "");
         xmlError = xmlDoc.Parse(fullHeader.c_str());
@@ -39,8 +39,7 @@ namespace gen {
           std::cout << "  >>> There is non-XML text at the end of this file\n";
         xmlError = tryRemoveTrailings(xmlDoc, fullHeader);
       } else {
-        std::string error =
-          "Fatal error when parsing the LHE header. The header is not valid XML! Parsing error was ";
+        std::string error = "Fatal error when parsing the LHE header. The header is not valid XML! Parsing error was ";
         error += xmlDoc.ErrorStr();
         throw cms::Exception("LHEWeightHelper") << error;
       }
@@ -85,7 +84,7 @@ namespace gen {
           std::cout << ">>>> Found a weight group: " << groupName << std::endl;
         for (auto inner = e->FirstChildElement("weight"); inner != nullptr; inner = inner->NextSiblingElement("weight"))
           addGroup(inner, groupName, groupIndex, weightIndex);
-      } 
+      }
       groupIndex++;
     }
     buildGroups();
@@ -103,8 +102,8 @@ namespace gen {
         return groupName;
       }
     }
-    bool hardFail = true;
-    if (hardFail) {
+
+    if (!fillEmptyIfWeightFails_) {
       throw std::runtime_error("couldn't find groupname");
     }
     return "";
@@ -119,8 +118,7 @@ namespace gen {
         if (curLevel != 0) {
           return false;
         }
-      }
-      else if (line.find("weightgroup") != std::string::npos) {
+      } else if (line.find("weightgroup") != std::string::npos) {
         curLevel++;
         if (curLevel != 1) {
           return false;
@@ -178,13 +176,13 @@ namespace gen {
     else if (fullHeader.find("&lt;") != std::string::npos || fullHeader.find("&gt;") != std::string::npos)
       return ErrorType::HTMLStyle;
     else if (xmlError != 0) {
-      std::string trailingCand = fullHeader.substr(fullHeader.rfind(weightgroupKet_) + std::string(weightgroupKet_).length());
+      std::string trailingCand =
+          fullHeader.substr(fullHeader.rfind(weightgroupKet_) + std::string(weightgroupKet_).length());
       if (trailingCand.find('<') == std::string::npos || trailingCand.find('>') == std::string::npos)
         return ErrorType::TrailingStr;
       else
         return ErrorType::Unknown;
-    }
-    else
+    } else
       return ErrorType::NoError;
   }
 }  // namespace gen

--- a/GeneratorInterface/Core/src/WeightHelper.cc
+++ b/GeneratorInterface/Core/src/WeightHelper.cc
@@ -124,7 +124,7 @@ namespace gen {
     std::string lhaidText = searchAttributes("pdf", weight);
 
     if (debug_)
-        std::cout << "Looking for LHAPDF info in ID " << lhaidText << std::endl;
+      std::cout << "Looking for LHAPDF info in ID " << lhaidText << std::endl;
 
     if (!lhaidText.empty()) {
       try {
@@ -145,7 +145,7 @@ namespace gen {
   void WeightHelper::updatePdfInfo(gen::PdfWeightGroupInfo& pdfGroup, const ParsedWeight& weight) {
     int lhaid = lhapdfId(weight, pdfGroup);
     if (debug_)
-        std::cout << "LHAID identified as " << lhaid << std::endl;
+      std::cout << "LHAID identified as " << lhaid << std::endl;
     if (pdfGroup.parentLhapdfId() < 0) {
       int parentId = lhaid - LHAPDF::lookupPDF(lhaid).second;
       pdfGroup.setParentLhapdfInfo(parentId);
@@ -244,9 +244,9 @@ namespace gen {
       group.addContainedId(weightNum, name, name);
     }
 
-    int entry = !isUnassociated ? group.weightVectorEntry(name, weightNum) : group.nIdsContained();
+    int entry = !isUnassociated ? group.weightVectorEntry(name, weightNum) : group.nIdsContained() - 1;
     if (debug_)
-      std::cout << "Adding weight " << entry << " to group " << groupIndex;
+      std::cout << "Adding weight " << entry << " to group " << groupIndex << std::endl;
     product->addWeight(weight, groupIndex, entry);
     return groupIndex;
   }

--- a/GeneratorInterface/Core/src/WeightHelper.cc
+++ b/GeneratorInterface/Core/src/WeightHelper.cc
@@ -136,7 +136,7 @@ namespace gen {
       return pdfGroup.lhaIds().back() + 1;
     } else {
       if (debug_)
-          std::cout << "Looking up LHAPDF ID from name" << weight.groupname << std::endl;
+        std::cout << "Looking up LHAPDF ID from name" << weight.groupname << std::endl;
       return LHAPDF::lookupLHAPDFID(weight.groupname);
     }
     return -1;
@@ -221,22 +221,22 @@ namespace gen {
       isUnassociated = true;
 
       bool foundUnassocGroup = false;
-      while (!foundUnassocGroup && groupIndex < static_cast<int>(weightGroups_.size())) {
+      for (; static_cast<size_t>(groupIndex) < weightGroups_.size(); ++groupIndex) {
         auto& g = weightGroups_[groupIndex];
-        if (g.weightType() == gen::WeightType::kUnknownWeights && g.name() == "unassociated")
+        if (g.weightType() == gen::WeightType::kUnknownWeights && g.name() == "unassociated") {
           foundUnassocGroup = true;
-        else
-          groupIndex++;
+          break;
+        }
       }
       if (!foundUnassocGroup) {
         addUnassociatedGroup();
+        product->addWeightSet();  // Unaccounted for weights need a place
       }
     }
-
     // This should be impossible, but in case the try/catch doesn't work, come here
     if (groupIndex < 0 || groupIndex >= static_cast<int>(weightGroups_.size()))
-        throw cms::Exception("Unmatched Generator weight! ID was " + name + " index was " + std::to_string(weightNum) +
-                    "\nNot found in any of " + std::to_string(weightGroups_.size()) + " weightGroups.");
+      throw cms::Exception("Unmatched Generator weight! ID was " + name + " index was " + std::to_string(weightNum) +
+                           "\nNot found in any of " + std::to_string(weightGroups_.size()) + " weightGroups.");
 
     auto& group = weightGroups_[groupIndex];
 
@@ -270,7 +270,7 @@ namespace gen {
     }
     // Needs to be properly handled
     throw cms::Exception("Unmatched Generator weight! ID was " + wgtId + " index was " + std::to_string(weightIndex) +
-                   "\nNot found in any of " + std::to_string(weightGroups_.size()) + " weightGroups.");
+                         "\nNot found in any of " + std::to_string(weightGroups_.size()) + " weightGroups.");
     return -1;
   }
 
@@ -321,31 +321,27 @@ namespace gen {
     }
     if (isScaleWeightGroup(weight)) {
       if (debug_)
-          std::cout << "Weight type is scale\n";
+        std::cout << "Weight type is scale\n";
       return std::make_unique<ScaleWeightGroupInfo>(weight.groupname);
-    }
-    else if (isPdfWeightGroup(weight)) {
+    } else if (isPdfWeightGroup(weight)) {
       if (debug_)
-          std::cout << "Weight type is PDF\n";
+        std::cout << "Weight type is PDF\n";
       return std::make_unique<PdfWeightGroupInfo>(weight.groupname);
-    }
-    else if (isMEParamWeightGroup(weight)) {
+    } else if (isMEParamWeightGroup(weight)) {
       if (debug_)
-          std::cout << "Weight type is MEParam\n";
+        std::cout << "Weight type is MEParam\n";
       return std::make_unique<MEParamWeightGroupInfo>(weight.groupname);
-    }
-    else if (isPartonShowerWeightGroup(weight)) {
+    } else if (isPartonShowerWeightGroup(weight)) {
       if (debug_)
-          std::cout << "Weight type is parton shower\n";
+        std::cout << "Weight type is parton shower\n";
       return std::make_unique<PartonShowerWeightGroupInfo>("shower");
-    }
-    else if (isOrphanPdfWeightGroup(weight)) {
+    } else if (isOrphanPdfWeightGroup(weight)) {
       if (debug_)
-          std::cout << "Weight type is PDF\n";
+        std::cout << "Weight type is PDF\n";
       return std::make_unique<PdfWeightGroupInfo>(weight.groupname);
     }
     if (debug_)
-        std::cout << "Weight type is unknown\n";
+      std::cout << "Weight type is unknown\n";
 
     std::cout << "Group name is " << weight.groupname << std::endl;
 
@@ -365,7 +361,7 @@ namespace gen {
       if (weight.wgtGroup_idx == numGroups) {
         std::cout << "Building a group";
         weightGroups_.push_back(*buildGroup(weight));
-        std::cout << "The name is now " << weightGroups_[weightGroups_.size()-1].name() << std::endl;
+        std::cout << "The name is now " << weightGroups_[weightGroups_.size() - 1].name() << std::endl;
       } else if (weight.wgtGroup_idx >= numGroups)
         throw cms::Exception("Invalid group index " + std::to_string(weight.wgtGroup_idx));
 

--- a/PhysicsTools/NanoAOD/python/genWeights_cff.py
+++ b/PhysicsTools/NanoAOD/python/genWeights_cff.py
@@ -10,6 +10,7 @@ lheWeights = cms.EDProducer("LHEWeightProductProducer",
     lheSourceLabels = cms.vstring(["externalLHEProducer", "source"]),
     failIfInvalidXML = cms.untracked.bool(False),
     debug = cms.untracked.bool(False),
+    fillEmptyIfWeightFails = cms.untracked.bool(False),
 )
 
 genWeightsTable = cms.EDProducer(

--- a/PhysicsTools/NanoAOD/python/genWeights_cff.py
+++ b/PhysicsTools/NanoAOD/python/genWeights_cff.py
@@ -4,6 +4,7 @@ genWeights = cms.EDProducer("GenWeightProductProducer",
     genInfo = cms.InputTag("generator"),
     genLumiInfoHeader = cms.InputTag("generator"),
     debug = cms.untracked.bool(False),
+    fillEmptyIfWeightFails = cms.untracked.bool(True),
 )
 
 lheWeights = cms.EDProducer("LHEWeightProductProducer",


### PR DESCRIPTION
#### PR description:

Two commits aimed at fixing some bugs and adding some features.

First adds the "fillEmptyIfWeightFails" option. Still needs to be worked on. The only convenient spot I found to put it was in the GenWeightProductProducer. If that fails, it resizes the weight vector to 1 (aka, only the central weight) and continues on. This may be unintented and certainly can be expanded, but in my cursory look, this was the most obvious spot to place it.

Further, some errors were resolved. The CMSDriver commands and what is changed are explained below:

 `# with command line options: step1 --filein dbs:/ZZTo4L_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIIAutumn18MiniAOD-102X_upgrade2018_realistic_v15-v1/MINIAODSIM --fileout blah.root --mc --eventcontent NANOAODGEN --datatier NANOAODSIM --conditions auto:mc --step NANOGEN --nThreads 1 --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1 --python_filename ZZTo4L_cfg.py`

This was the error mentioned by Sanghyun. The problem is conflict in how the xml file is cleaned: if the file is not consistent, it changes the actual header vector, if anything else is not working, it changes the string DERIVED from the header vector. This was causing conflict when the `isConsistent` function failed to see the xml wasn't consistent because of &lt; escape characters, so the escape characters were fixed to then the string that was fixed was replaced by the fixing of the consistency problem. 

That might not have made a ton of sense, but the take away is the Error handling was retooled a bit. It could definitely be done in a different way, but I opted for more modern code, ie `enum class` and if/else instead of case blocks

`# with command line options: step1 --filein dbs:/WWJTo2L2Nu_NNLOPS_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM --fileout blah.root --mc --eventcontent NANOAODGEN --datatier NANOAODSIM --conditions auto:mc --step NANOGEN --nThreads 1 --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1 --python_filename WJ_cfg.py`

This file has weights not included in the header, namely NNLOP weights for random PDF weights, eg if PDF weight exists, there may be a NNLOP version of these weights that is not specified. The fix to the problem is to make sure that when adding an Unassociated Group that the product vector's size has to also be updated. Since this was causing the weight to fail though, it acted as a test for the `fillEmptyIfWeightFails` option.

I will be testing on more files, but these were files that straight up failed I've tested on so far

